### PR TITLE
Allow install on Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "laravel/framework": "~5.7|~5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "laravel/framework": "~5.7|~5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "spatie/laravel-medialibrary": "^9.0|^10.0|^11.0",
         "php-ffmpeg/php-ffmpeg": "^1.0"
     },


### PR DESCRIPTION
This allows the package to be installed on Laravel 12

If this gets merged then I'm happy to PR an update to tests so that there is test coverage for Laravel 10, 11 and 12